### PR TITLE
change kabenaro labeling and fix old cli install link

### DIFF
--- a/_content/apps/cp4a-prereq.md
+++ b/_content/apps/cp4a-prereq.md
@@ -5,8 +5,8 @@ weight: 150
 
 Refer to Knowledge Center [prerequisites](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-prerequisites.html) for details on what is required before starting an install.
 
-Refer to [OpenShift Container Platform section](../../ocp/prerequisites/) for prerequisites on installing a cluster.  
+Refer to [OpenShift Container Platform section](../../ocp/prerequisites/) for prerequisites on installing a cluster.
 
 Refer to [tools installation](../cp4a_install_dev_tools_mac/) for prerequisites for developer client install.
 
-Sizing information is also available in the [prerequisites](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-prerequisites.html)
+Sizing information is also available in the [prerequisites](https://www.ibm.com/support/knowledgecenter/SSCSJL_4.x/install-prerequisites.html)

--- a/_content/apps/cp4a-prereq.md
+++ b/_content/apps/cp4a-prereq.md
@@ -3,7 +3,7 @@ title: Prerequisites
 weight: 150
 ---
 
-Refer to Knowledge Center [prerequisites](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-prerequisites.html) for details on what is required before starting an install.
+Refer to Knowledge Center [prerequisites](https://www.ibm.com/support/knowledgecenter/SSCSJL_4.x/install-prerequisites.html) for details on what is required before starting an install.
 
 Refer to [OpenShift Container Platform section](../../ocp/prerequisites/) for prerequisites on installing a cluster.
 

--- a/_content/apps/cp4a_install_dev_tools_mac.md
+++ b/_content/apps/cp4a_install_dev_tools_mac.md
@@ -17,9 +17,9 @@ Before beginning these steps you should have:
 
 ## Installing Client tools from web pages on the cluster
 
-Two web pages will be created, as part of installing the OpenShift Container Platform cluster and the Cloud Pak for Applications. 
+Two web pages will be created, as part of installing the OpenShift Container Platform cluster and the Cloud Pak for Applications.
 The two landing pages can be found in the Cluster Console under Routes and are named kabanero-landing and icpa-landing.
-It is recommended that you use these pages to get the most current installation information about the client tools. 
+It is recommended that you use these pages to get the most current installation information about the client tools.
 This document will also provide links to these tools on the web.
 
 When the OpenShift cluster is created, a reference page is generated for the OpenShift command line tools. There are several useful links on this page. Get this URL from your administrator.
@@ -31,7 +31,7 @@ When the OpenShift cluster is created, a reference page is generated for the Ope
 
 **Note:** You will need to authenticate (login) to your cluster.
 
-When the Cloud Pak for Applications is installed, a "landing page" is created for the Kabanero Enterprise edition. Your administrator can give you this URL.
+When the Cloud Pak for Applications is installed, a "landing page" is created for Kabanero. Your administrator can give you this URL.
 {%
  include figure.html
  src="/assets/img/cp4a/kabanero.png"
@@ -48,7 +48,7 @@ On mac `git` is installed by default. You may use `which git` to validate that 
 ### OpenShift command line interface (oc)
 
 More information can be found here:
-https://docs.openshift.com/container-platform/3.11/cli_reference/get_started_cli.html#installing-the-cli For complete installation instructions there is a video you should watch.
+https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html For complete installation instructions there is a video you should watch.
 **Note:** You will need to login using your RedHat customer account.
 
 oc is also available from https://github.com/openshift/origin/releases

--- a/_content/apps/cp4a_install_dev_tools_win.md
+++ b/_content/apps/cp4a_install_dev_tools_win.md
@@ -26,7 +26,7 @@ When the OpenShift cluster is created, a reference page is generated for the Ope
 
 **Note:** You will need to authenticate (login) to your cluster.
 
-When the Cloud Pak for Applications is installed, a "landing page" is created for the Kabanero Enterprise edition. Your administrator can give you this URL.
+When the Cloud Pak for Applications is installed, a "landing page" is created for Kabanero. Your administrator can give you this URL.
 {%
  include figure.html
  src="/assets/img/cp4a/kabanero.png"
@@ -44,7 +44,7 @@ Install git for windows from: https://gitforwindows.org/
 ### OpenShift OpenShift command line interface (oc)
 
 More information can be found here:
-https://docs.openshift.com/container-platform/3.11/cli_reference/get_started_cli.html#installing-the-cli For complete installation instructions there is a video you should watch.
+https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html For complete installation instructions there is a video you should watch.
 **Note:** You will need to login using your RedHat customer account.
 
 oc is also available from https://github.com/openshift/origin/releases

--- a/_content/apps/cp4a_installation.md
+++ b/_content/apps/cp4a_installation.md
@@ -6,7 +6,7 @@ weight: 200
 ## Cloud Pak for Applications Installer
 
 The Cloud Pak for Applications Installer installs the following components on your Red Hat OpenShift Container Platform cluster:
-- IBM Kabanero Enterprise
+- Kabanero
 - IBM Cloud Transformation Advisor
 
 These components install into an existing clusters including an on-premises cluster or Red Hat OpenShift on IBM Cloud  service.
@@ -17,7 +17,7 @@ OpenShift can be obtained through the Cloud Pak or a Red Hat OpenShift subscript
 ## Cloud Pak for Applications Installer
 
 The Cloud Pak for Applications Installer installs the following components on your OCP Cluster:
-- Kabanero Enterprise
+- Kabanero
 - Transformation Advisor
 
 Only installation from an entitled registry is supported.
@@ -26,17 +26,17 @@ The installer must have access to both the entitled registry and the target clus
 
 ### Prerequisites
 
-The [prerequisites](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-prerequisites.html) include Red Hat OpenShift Container Platform (OCP) version 3.11.
+The [prerequisites](https://www.ibm.com/support/knowledgecenter/SSCSJL_4.x/install-prerequisites.html) include Red Hat OpenShift Container Platform (OCP) version 4.2.
 
 ### Installation
 
-The full set of [instructions for installing Cloud Pak for Applications](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-icpa-cli.html) is found in the IBM Knowledge Center.  The installation can per performed from a workstation that is not one of the VMs in the cluster.  This workstation must have access to the entitled registry, the OCP/OKD cluster and the Internet.
+The full set of [instructions for installing Cloud Pak for Applications](https://www.ibm.com/support/knowledgecenter/SSCSJL_4.x/install-icpa-cli.html) is found in the IBM Knowledge Center.  The installation can per performed from a workstation that is not one of the VMs in the cluster.  This workstation must have access to the entitled registry, the OCP/OKD cluster and the Internet.
 
 If the OCP/OKD app subdomain is set in the cluster, there is no need to edit the generated config.yaml file.  The installation can be started with all default values.
 
-### Workarounds for Kabanero Enterprise
+### Workarounds for Kabanero
 
-In version `3.0.0.0` of Kabanero Enterprise the appsody operator can only deploy applications in the `kabanero` namespace.
+In version `3.0.0.0` of Kabanero the appsody operator can only deploy applications in the `kabanero` namespace.
 
 To work around this problem a second appsody operator needs to be deployed with a cluster scope that watches all namespaces.
 

--- a/_content/apps/cp4a_installation.md
+++ b/_content/apps/cp4a_installation.md
@@ -9,10 +9,10 @@ The Cloud Pak for Applications Installer installs the following components on yo
 - IBM Kabanero Enterprise
 - IBM Cloud Transformation Advisor
 
-These components install into an existing clusters including an on-premises cluster or Red Hat OpenShift on IBM Cloud  service.  
+These components install into an existing clusters including an on-premises cluster or Red Hat OpenShift on IBM Cloud  service.
 OpenShift can be obtained through the Cloud Pak or a Red Hat OpenShift subscription.
 
-[Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-icpa-cli.html) details how to use the installer command line. 
+[Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSCSJL_4.x/install-icpa-cli.html) details how to use the installer command line.
 
 ## Cloud Pak for Applications Installer
 
@@ -20,9 +20,9 @@ The Cloud Pak for Applications Installer installs the following components on yo
 - Kabanero Enterprise
 - Transformation Advisor
 
-Only installation from an entitled registry is supported.  
-Air gapped installations are **not** supported.  
-The installer must have access to both the entitled registry and the target cluster from the same workstation.  
+Only installation from an entitled registry is supported.
+Air gapped installations are **not** supported.
+The installer must have access to both the entitled registry and the target cluster from the same workstation.
 
 ### Prerequisites
 
@@ -30,7 +30,7 @@ The [prerequisites](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-p
 
 ### Installation
 
-The full set of [instructions for installing Cloud Pak for Applications](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-icpa-cli.html) is found in the IBM Knowledge Center.  The installation can per performed from a workstation that is not one of the VMs in the cluster.  This workstation must have access to the entitled registry, the OCP/OKD cluster and the Internet.  
+The full set of [instructions for installing Cloud Pak for Applications](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-icpa-cli.html) is found in the IBM Knowledge Center.  The installation can per performed from a workstation that is not one of the VMs in the cluster.  This workstation must have access to the entitled registry, the OCP/OKD cluster and the Internet.
 
 If the OCP/OKD app subdomain is set in the cluster, there is no need to edit the generated config.yaml file.  The installation can be started with all default values.
 
@@ -40,7 +40,7 @@ In version `3.0.0.0` of Kabanero Enterprise the appsody operator can only deploy
 
 To work around this problem a second appsody operator needs to be deployed with a cluster scope that watches all namespaces.
 
-Take into account that the namespace `kabanero` will be watched by both appsody operators, this means that no applications should be depoyed into the `kabanero` namespace. 
+Take into account that the namespace `kabanero` will be watched by both appsody operators, this means that no applications should be depoyed into the `kabanero` namespace.
 The user is required to set the namespace in the `app-deploy.yaml` in the appsody application git repository.
 
 

--- a/_content/apps/cp4a_learn_more.md
+++ b/_content/apps/cp4a_learn_more.md
@@ -12,6 +12,6 @@ weight: 700
 
 ## References
 
-- [Knowledge Center for Cloud Pak for Applications](https://www-03preprod.ibm.com/support/knowledgecenter/SSCSJL/about-overview.html)
+- [Knowledge Center for Cloud Pak for Applications](https://www-03preprod.ibm.com/support/knowledgecenter/SSCSJL_4.x/about-overview.html)
 - [Kabanero](https://kabanero.io/)
 - [Red Hat Runtimes for IBM Cloud Pak for Applications Customers](https://access.redhat.com/articles/4394291)

--- a/_content/apps/cp4a_overview.md
+++ b/_content/apps/cp4a_overview.md
@@ -45,7 +45,7 @@ These offerings are also included in the Cloud Pak for Applications but not focu
 ## Installation Overview
 
 The primary method for installing the Cloud Pak for Applications follows the key high level steps of:
-- **Install Red Hat OpenShift Container Platform** -  Cloud Pak provides OpenShift Container Platform to create a new cluster.  You can also use any existing OpenShift 3.11 to install the Cloud Pak into.
-- **Install Cloud Pak for Applications**  - The Cloud Pak is installed into the cluster and provides Transformation Advisor and IBM Kabanero Enterprise.  The installation provides IBM runtimes for Liberty, Microprofile, and Spring, as well as several open source projects which include Appsody, Tekton, and Knative.
+- **Install Red Hat OpenShift Container Platform** -  Cloud Pak provides OpenShift Container Platform to create a new cluster.  You can also use any existing OpenShift 4.2 to install the Cloud Pak into.
+- **Install Cloud Pak for Applications**  - The Cloud Pak is installed into the cluster and provides Transformation Advisor and Kabanero.  The installation provides IBM runtimes for Liberty, Microprofile, and Spring, as well as several open source projects which include Appsody, Tekton, and Knative.
 - **Install developer tools** - A developer is provided tools for an IDE and key CLIs to access the cluster.  Instructions are available for both Mac OSx and Windows.
 - **Building DevOps Pipeline to Reuse Runtimes** - TBD.

--- a/_content/apps/cp4a_overview.md
+++ b/_content/apps/cp4a_overview.md
@@ -28,7 +28,7 @@ The key offerings reviewed in this installation and usage scenarios are:
 | Offering | Installation Steps | Description |
 | -------- | ------------------ | ----------- |
 | Red Hat OpenShift Container Platform | [Install](../../ocp/introduction) | Kubernetes platform required for running application workloads |
-| IBM Kabanero Enterprise | [Install](../cp4a_installation) | Open source projects to build, deploy and run applications.  Installs into an OpenShift Container Platform cluster. |
+| Kabanero | [Install](../cp4a_installation) | Open source projects to build, deploy and run applications.  Installs into an OpenShift Container Platform cluster. |
 | Developer Tools | [MacOS](../cp4a_install_dev_tools_mac) / [Windows](../cp4a_install_dev_tools_win) | Tools needed for a developer to build, test and debug applications.
 | Red Hat Runtimes | [Install](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-icpa.html) | Application runtimes and framework for JBoss, Vert.x and Node. |
 
@@ -48,3 +48,4 @@ The primary method for installing the Cloud Pak for Applications follows the key
 - **Install Red Hat OpenShift Container Platform** -  Cloud Pak provides OpenShift Container Platform to create a new cluster.  You can also use any existing OpenShift 3.11 to install the Cloud Pak into.
 - **Install Cloud Pak for Applications**  - The Cloud Pak is installed into the cluster and provides Transformation Advisor and IBM Kabanero Enterprise.  The installation provides IBM runtimes for Liberty, Microprofile, and Spring, as well as several open source projects which include Appsody, Tekton, and Knative.
 - **Install developer tools** - A developer is provided tools for an IDE and key CLIs to access the cluster.  Instructions are available for both Mac OSx and Windows.
+- **Building DevOps Pipeline to Reuse Runtimes** - TBD.

--- a/_content/apps/cp4a_overview.md
+++ b/_content/apps/cp4a_overview.md
@@ -21,7 +21,7 @@ The focus provided here is on running application workloads as containers.
 The Cloud Pak for Applications is a bundle of multiple offerings.
 This diagram provides an overview of what offerings are included and what they would be used for.
 
-![Overview](https://www.ibm.com/support/knowledgecenter/SSCSJL/images/icpa_overview.png)
+![Overview](https://www.ibm.com/support/knowledgecenter/SSCSJL_4.x/images/icpa_overview.png)
 
 The key offerings reviewed in this installation and usage scenarios are:
 
@@ -30,17 +30,17 @@ The key offerings reviewed in this installation and usage scenarios are:
 | Red Hat OpenShift Container Platform | [Install](../../ocp/introduction) | Kubernetes platform required for running application workloads |
 | Kabanero | [Install](../cp4a_installation) | Open source projects to build, deploy and run applications.  Installs into an OpenShift Container Platform cluster. |
 | Developer Tools | [MacOS](../cp4a_install_dev_tools_mac) / [Windows](../cp4a_install_dev_tools_win) | Tools needed for a developer to build, test and debug applications.
-| Red Hat Runtimes | [Install](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-icpa.html) | Application runtimes and framework for JBoss, Vert.x and Node. |
+| Red Hat Runtimes | [Install](https://www.ibm.com/support/knowledgecenter/SSCSJL_4.x/install-icpa.html) | Application runtimes and framework for JBoss, Vert.x and Node. |
 
 These offerings are also included in the Cloud Pak for Applications but not focus within this material.  These offerings support running existing applications but not focused on the container platform.
 
 | Offering | Installation Steps | Description |
 | -------- | ------------------ | ----------- |
-| IBM WebSphere Application Server Network Deployment | [Install](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-icpa.html) | Continue to run existing WebSphere apps. |
-| IBM WebSphere Application Server | [Install](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-icpa.html) | Continue to run existing WebSphere apps. |
-| IBM WebSphere Application Server Liberty Core | [Install](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-icpa.html) | Continue to run existing Liberty apps.
-| IBM Mobile Foundation | [Install](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-icpa.html) | Run existing mobile apps. |
-| IBM Cloud Private |[Install](https://www.ibm.com/support/knowledgecenter/SSCSJL/install-icpa.html) | Migrate existing workloads to OpenShift Container Platform. |
+| IBM WebSphere Application Server Network Deployment | [Install](https://www.ibm.com/support/knowledgecenter/SSCSJL_4.x/install-icpa.html) | Continue to run existing WebSphere apps. |
+| IBM WebSphere Application Server | [Install](https://www.ibm.com/support/knowledgecenter/SSCSJL_4.x/install-icpa.html) | Continue to run existing WebSphere apps. |
+| IBM WebSphere Application Server Liberty Core | [Install](https://www.ibm.com/support/knowledgecenter/SSCSJL_4.x/install-icpa.html) | Continue to run existing Liberty apps.
+| IBM Mobile Foundation | [Install](https://www.ibm.com/support/knowledgecenter/SSCSJL_4.x/install-icpa.html) | Run existing mobile apps. |
+| IBM Cloud Private |[Install](https://www.ibm.com/support/knowledgecenter/SSCSJL_4.x/install-icpa.html) | Migrate existing workloads to OpenShift Container Platform. |
 
 ## Installation Overview
 

--- a/_content/apps/cp4a_use_case_app_mod.md
+++ b/_content/apps/cp4a_use_case_app_mod.md
@@ -3,39 +3,39 @@ title: Modernize existing applications
 weight: 500
 ---
 
-## Introduction 
+## Introduction
 
-On the journey to cloud, enterprise customers are facing challenges moving their existing on-premises applications to cloud quickly and cost-effectively.  
+On the journey to cloud, enterprise customers are facing challenges moving their existing on-premises applications to cloud quickly and cost-effectively.
 
-The IBM Cloud Pak for Applications provides a complete and consistent experience and solution to modernize enterprise applications for cloud-native deployments. Customers can easily modernize their existing applications with IBM’s integrated tools and develop new cloud-native applications faster for deployment on any cloud.  
+The IBM Cloud Pak for Applications provides a complete and consistent experience and solution to modernize enterprise applications for cloud-native deployments. Customers can easily modernize their existing applications with IBM’s integrated tools and develop new cloud-native applications faster for deployment on any cloud.
 
-One of the tools included in the Pak is the IBM Cloud Transformation Advisor (TA), a developer tool that is available at no charge to help you quickly evaluate on-premises Java EE applications for deployment to the cloud. 
+One of the tools included in the Pak is the IBM Cloud Transformation Advisor (TA), a developer tool that is available at no charge to help you quickly evaluate on-premises Java EE applications for deployment to the cloud.
 
 The Transformation Advisor tool can:
 
 - identify the Java EE programming models in the app.
 - determine the complexity of apps by listing a high-level inventory of the content and structure of each app.
 - highlight Java EE programming model and WebSphere API differences between the WebSphere profile types
-- gain insights into Java EE specification implementation differences that might affect the application. 
- 
+- gain insights into Java EE specification implementation differences that might affect the application.
 
-Additionally, the tool provides a recommendation for the right-fit IBM WebSphere Application Server edition and offers advice, best practices and potential solutions to assess the ease of moving apps to Liberty or to newer versions of WebSphere traditional. 
+
+Additionally, the tool provides a recommendation for the right-fit IBM WebSphere Application Server edition and offers advice, best practices and potential solutions to assess the ease of moving apps to Liberty or to newer versions of WebSphere traditional.
 
 It helps accelerate application migrating to cloud, while minimizing errors and risks.
 
 ## Transformation Advisor Migration Plan
 
-Once you have decided on an application you would like to migrate, you will work with the Migration Plan. 
+Once you have decided on an application you would like to migrate, you will work with the Migration Plan.
 
- Using the TA migration plan, TA automatically generates the artifacts you will need to containerize your application running on WebSphere Liberty and deploy to containers on Redhat OpenShift. 
- 
- You will have the opportunity on this page to upload your application binaries and any external drivers that TA detected that you may need. 
- 
- After the migration bundle is prepared, you have options either to push the bundle to a GitHub repository or download them in a single zip to do more changes and to deploy the bundle manually. 
- 
- A pdf document is included in the migration bundle that provides detailed instructions on the next steps you need to take to migrate the application. Those steps are highlighted in the next section of this document. 
+ Using the TA migration plan, TA automatically generates the artifacts you will need to containerize your application running on WebSphere Liberty and deploy to containers on Redhat OpenShift.
 
-If you download the migration bundle to your local machine and modify the generated artifacts to suite your environment and specific application requirements, you can follow the steps in the next section to migrate / modernize the application to containers on Liberty runtime with Redhat OpenShift. 
+ You will have the opportunity on this page to upload your application binaries and any external drivers that TA detected that you may need.
+
+ After the migration bundle is prepared, you have options either to push the bundle to a GitHub repository or download them in a single zip to do more changes and to deploy the bundle manually.
+
+ A pdf document is included in the migration bundle that provides detailed instructions on the next steps you need to take to migrate the application. Those steps are highlighted in the next section of this document.
+
+If you download the migration bundle to your local machine and modify the generated artifacts to suite your environment and specific application requirements, you can follow the steps in the next section to migrate / modernize the application to containers on Liberty runtime with Redhat OpenShift.
 
 ## Migration Steps - Overview
 
@@ -49,7 +49,7 @@ You will complete the following steps:
 
     - Tag and add the image to the Red Hat OpenShift image repository and create a running instance of your application.
 
-3. Cleanup (Optional) 
+3. Cleanup (Optional)
 
 
 Variable definitions for tasks in this document:
@@ -86,7 +86,7 @@ operator/application/application-cr.yaml file) assume that the default Docker Re
 
 If you are using the OpenShift cluster private registry, you will need to complete the
 following:
-- Consult the Red Hat OpenShift documentation to configure OpenShift's Docker Registry to be externally accessible. Once configured, you can push your image from the location where you built it in the previous step. 
+- Consult the Red Hat OpenShift documentation to configure OpenShift's Docker Registry to be externally accessible. Once configured, you can push your image from the location where you built it in the previous step.
 - Ensure the docker service is running. If it's not, start it:
 
 ```
@@ -118,7 +118,7 @@ This allows you to browse the file system of the container where your applicatio
 In this step you will deploy the docker image you have created to Red Hat OpenShift and create an instance of it.
 
 
-IMPORTANT: The YAML file generated by Transformation Advisor assumes that the OpenShift project name is the same as the <APPLICATION_NAME>. 
+IMPORTANT: The YAML file generated by Transformation Advisor assumes that the OpenShift project name is the same as the <APPLICATION_NAME>.
 
 If you choose another project name, you must update the <MIGRATION_ARTIFACTS_HOME>/operator/application/application.cr.yaml file to change the repository name for the image location to match your chosen project name:
 
@@ -155,7 +155,7 @@ Tag your image appropriately. Ensure that your OpenShift project (namespace) is 
    ```
 
 Login to docker registry:
-   
+
    ```
     docker login -u $(oc whoami) -p $(oc whoami -t) <DOCKER_REGISTRY>
    ```
@@ -166,7 +166,7 @@ Push the image to the registry:
     docker push <DOCKER_REGISTRY>/<OCP_PROJECT>/<IMAGE_NAME>:latest
    ```
 
-Optional: To do a quick deploy and test of the image, you can deploy using the OpenShift UI. Consult the Open Shift documentation for more details: [https://docs.openshift.com/containerplatform/3.11/welcome/index.html](https://docs.openshift.com/containerplatform/3.11/welcome/index.html)
+Optional: To do a quick deploy and test of the image, you can deploy using the OpenShift UI. Consult the Open Shift documentation for more details: [https://docs.openshift.com/container-platform/4.2/welcome/index.html](https://docs.openshift.com/container-platform/4.2/welcome/index.html)
 
 **Recommended** Deploy your image with its accompanying operator using the following instructions:
 


### PR DESCRIPTION
* remove IBM ENTERPRISE from Kabenero
* adjust hyperlink for App Mod Install overview
* add bullet to install process
* replace 3.11 references with 4.2 and related links